### PR TITLE
Fix generate_linking_command_line to specify all object files

### DIFF
--- a/lib/mkmf-cu/opt.rb
+++ b/lib/mkmf-cu/opt.rb
@@ -115,7 +115,7 @@ def generate_linking_command_line(argv, opt_h)
       case op
       when "-o", "-c"
         s << " #{op} #{e}"
-        s << " " + argv[0] + " " if op == "-o"
+        s << " " + argv.join(" ") + " " if op == "-o"
       else
         s << " #{op}#{e}"
       end


### PR DESCRIPTION
In my project:

```
[given command line options]: --mkmf-cu-ext=c -shared -o cumo.so cumo.o narray/narray.o narray/array.o narray/step.o narray/index.o narray/ndloop.o narray/data.o narray/types/bit.o narray/types/int8.o narray/types/int16.o narray/types/int32.o narray/types/int64.o narray/types/uint8.o narray/types/uint16.o narray/types/uint32.o narray/types/uint64.o narray/types/sfloat.o narray/types/dfloat.o narray/types/scomplex.o narray/types/dcomplex.o narray/types/robject.o narray/math.o narray/SFMT.o narray/struct.o narray/rand.o cuda/driver.o cuda/runtime.o cuda/nvrtc.o -L. -L/home/sonots/.rbenv/versions/2.4.1/lib -Wl,-R/home/sonots/.rbenv/versions/2.4.1/lib -L/home/sonots/.cudnn/active/cuda/lib64 -Wl,-R/home/sonots/.cudnn/active/cuda/lib64 -L/usr/lib/x86_64-linux-gnu -Wl,-R/usr/lib/x86_64-linux-gnu -L/usr/local/cuda/lib64 -Wl,-R/usr/local/cuda/lib64 -L/usr/local/cuda/lib -Wl,-R/usr/local/cuda/lib -L. -L/home/sonots/.rbenv/versions/2.4.1/lib -L /home/sonots/nccl/build/lib -I /home/sonots/.cudnn/active/cuda/include -fstack-protector -rdynamic -Wl,-export-dynamic -L/home/sonots/.rbenv/versions/2.4.1/lib -L /home/sonots/nccl/build/lib -I /home/sonots/.cudnn/active/cuda/include -Wl,--compress-debug-sections=zlib -lnvrtc -lcudart -lcuda -lpthread -ldl -lcrypt -lm -lc
nvcc -L. -L/home/sonots/.rbenv/versions/2.4.1/lib -L/home/sonots/.cudnn/active/cuda/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib -L. -L/home/sonots/.rbenv/versions/2.4.1/lib -L/home/sonots/nccl/build/lib -L/home/sonots/.rbenv/versions/2.4.1/lib -L/home/sonots/nccl/build/lib -lnvrtc -lcudart -lcuda -lpthread -ldl -lcrypt -lm -lc -o cumo.so cumo.o  --compiler-options -fstack-protector -shared  --linker-options -R/home/sonots/.rbenv/versions/2.4.1/lib --linker-options -R/home/sonots/.cudnn/active/cuda/lib64 --linker-options -R/usr/lib/x86_64-linux-gnu --linker-options -R/usr/local/cuda/lib64 --linker-options -R/usr/local/cuda/lib --linker-options -export-dynamic --linker-options --compress-debug-sections=zlib --compiler-bindir gcc
```

That is, I want to get all object files specified, but mkmf-cu specified only one object file.